### PR TITLE
ERPNext v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
+# ERPNext dev environment using Vagrant: #
+
+1. Clone this repo into a local folder with `git clone https://github.com/frappe/erpnext_vagrant.git erpnext_vagrant`
+2. Start your virtual machine by running `vagrant up`
+3. Connect to your guest system via SSH with `vagrant ssh`
+4. Set `"developer_mode": 1` in `/home/vagrant/erpnext-bench/sites/erpnext.local/site_config.json`
+5. Go to your erpnext-bench folder with `cd /home/vagrant/erpnext-bench/` and start bench with `bench start`
+6. Open your browser on your host system and work on your ERPNExt by browsing to `http://localhost:8080/` or `http://127.0.0.1:8080`
+
+## vagrant up/provision with parameters
+
+
+### Environment variables which affects vagrant up/provision:
+
+| ENV variable  |     default   |
+| ------------- | ------------- |
+| BENCH_HOME | /home/vagrant |
+| BENCH_NAME | erpnext-bench |
+| BENCH_GIT |  https://github.com/frappe/bench |
+| MYSQL_ROOT_PWD | root |
+|  FRAPPE_SITE | erpnext.local |
+| FRAPPE_ADMIN_PWD | admin |
+| ERPNEXT_GIT |  https://github.com/frappe/erpnext.git |
+| APT_INSTALL | yes |
+
+
+### Example: using erpnext git repository, no apt-get install:
+
+    ERPNEXT_GIT=https://github.com/hernad/erpnext.git APT_INSTALL=no vagrant provision
+
+
 # Installing prerequisites under Windows: #
 
 1. Download and install **Virtual Box**. Attention! There are known problems with VirtualBox 5.0.2 on Windows 10 hosts and with Windows 10 guests. Some of the problems are fixed in the most recent test build which can be found at https://www.virtualbox.org/wiki/Testbuilds.
@@ -6,11 +37,4 @@
 4. From now on use **Git Shell** (on your Desktop) to run all commands since it supports some Linux commands natively, most importantly SSH. This means you won't have to install and set up Putty.
 5. (Optional) Install a good text editor such as **Atom** at https://atom.io/
 
-# Set up an ERPNext dev environment using Vagrant: #
 
-1. Clone this repo into a local folder with `git clone https://github.com/frappe/erpnext_vagrant.git erpnext_vagrant`
-2. Start your virtual machine by running `vagrant up`
-3. Connect to your guest system via SSH with `vagrant ssh`
-4. Set `"developer_mode": 1` in `/home/vagrant/erpnext-bench/sites/erpnext.local/site_config.json`, for example by running `vim /home/vagrant/erpnext-bench/sites/site1.local/site_config.json`. When in vim press `i` to insert text. After inserting press `ESC` and write `:wq` to write and quite the file. More on vim here https://www.linux.com/learn/tutorials/228600-vim-101-a-beginners-guide-to-vim.
-5. Go to your erpnext-bench folder with `cd /home/vagrant/erpnext-bench/` and start bench with `bench start`
-6. Open your browser on your host system and work on your ERPNExt by browsing to `http://localhost:8080/` or `http://127.0.0.1:8080`

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 4. From now on use **Git Shell** (on your Desktop) to run all commands since it supports some Linux commands natively, most importantly SSH. This means you won't have to install and set up Putty.
 5. (Optional) Install a good text editor such as **Atom** at https://atom.io/
 
-# Set up an ERPNext dev environment using Vagrant: # 
+# Set up an ERPNext dev environment using Vagrant: #
 
 1. Clone this repo into a local folder with `git clone https://github.com/frappe/erpnext_vagrant.git erpnext_vagrant`
 2. Start your virtual machine by running `vagrant up`
 3. Connect to your guest system via SSH with `vagrant ssh`
-4. Set `"developer_mode": 1` in `/vagrant/frappe-bench/sites/site1.local/site_config.json`, for example by running `vim /vagrant/frappe-bench/sites/site1.local/site_config.json`. When in vim press `i` to insert text. After inserting press `ESC` and write `:wq` to write and quite the file. More on vim here https://www.linux.com/learn/tutorials/228600-vim-101-a-beginners-guide-to-vim.
-5. Go to your frappe-bench folder with `cd /vagrant/frappe-bench/` and start bench with `bench start`
+4. Set `"developer_mode": 1` in `/home/vagrant/erpnext-bench/sites/erpnext.local/site_config.json`, for example by running `vim /home/vagrant/erpnext-bench/sites/site1.local/site_config.json`. When in vim press `i` to insert text. After inserting press `ESC` and write `:wq` to write and quite the file. More on vim here https://www.linux.com/learn/tutorials/228600-vim-101-a-beginners-guide-to-vim.
+5. Go to your erpnext-bench folder with `cd /home/vagrant/erpnext-bench/` and start bench with `bench start`
 6. Open your browser on your host system and work on your ERPNExt by browsing to `http://localhost:8080/` or `http://127.0.0.1:8080`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "ubuntu/trusty32"
+  config.vm.box = "ubuntu/trusty64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,72 +1,34 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# All Vagrant configuration is done below. The "2" in Vagrant.configure
-# configures the configuration version (we support older styles for
-# backwards compatibility). Please don't change it unless you know what
-# you're doing.
-Vagrant.configure(2) do |config|
-  # The most common configuration options are documented and commented below.
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
+$before_script = <<SCRIPT
+ 
+vag_prof=/etc/profile.d/vagrant.sh
+echo export BENCH_HOME=#{ENV['BENCH_HOME']} > $vag_prof
+echo export BENCH_NAME=#{ENV['BENCH_NAME']} >> $vag_prof
+echo export BENCH_GIT=#{ENV['BENCH_GIT']} >> $vag_prof
+echo export MYSQL_ROOT_PWD=#{ENV['MYSQL_ROOT_PWD']} >> $vag_prof
+echo export FRAPPE_SITE=#{ENV['FRAPPE_SITE']} >> $vag_prof
+echo export FRAPPE_ADMIN_PWD=#{ENV['FRAPPE_ADMIN_PWD']} >> $vag_prof
+echo export ERPNEXT_GIT=#{ENV['ERPNEXT_GIT']} >> $vag_prof
+echo export APT_INSTALL=#{ENV['APT_INSTALL']} >> $vag_prof
 
-  # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
+chmod +x $vag_prof
+SCRIPT
+
+
+
+Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
 
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
   config.vm.network "forwarded_port", guest: 8000, host: 8080
 
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
   config.vm.provider "virtualbox" do |vb|
-    # Display the VirtualBox GUI when booting the machine
     # vb.gui = true
-
     # Customize the amount of memory on the VM:
     vb.memory = "1024"
   end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
-  # end
-
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   sudo apt-get update
-  #   sudo apt-get install -y apache2
-  # SHELL
+  
+  config.vm.provision :shell, inline: $before_script
   config.vm.provision :shell, path: "bootstrap.sh"
 end


### PR DESCRIPTION
This patch makes these changes:

1) ubuntu 64bit as base vagrant box

2) /home/vagrant/erpnext-bench is the new bench location ( /vagrant/... is slow because this directory is synced with host)

3) node 0.12 install, required by master branch (erpnext v6)